### PR TITLE
Add Role Descriptions

### DIFF
--- a/static/game.js
+++ b/static/game.js
@@ -235,6 +235,11 @@ function renderDeadAndAliveInformation() {
         const alivePlayer = document.createElement("div");
         alivePlayer.setAttribute("class", "alive-player");
         alivePlayer.innerText = player.card.role;
+        //Add hidden description span - RTM 4/18/2020
+        let playerCardInfo=document.createElement("span");
+        playerCardInfo.setAttribute("class","tooltiptext");
+        playerCardInfo.innerText=player.card.description;
+        alivePlayer.appendChild(playerCardInfo);
         aliveContainer.appendChild(alivePlayer);
     });
     if (infoContainer === null) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -1446,3 +1446,26 @@ color: #333243;
 text-decoration: none;
 cursor: pointer;
 }
+/*Tooltip styles. Taken from w3schools*/
+#game-container .alive-player .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 50%;
+  left: 150%;
+  margin-left: -60px;
+  /* Fade in tooltip - takes 1 second to go from 0% to 100% opac: */
+  /*opacity: 0;*/
+  /*transition: opacity 1s;*/
+}
+
+#game-container .alive-player:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}


### PR DESCRIPTION
Role descriptions added via hidden span via CSS tooltip. Shows visible when moused over on desktop or tapped on mobile. I wasn't able to test this on mobile, so I'm not sure how well it looks there as the CSS is a position absolute, but the position is in percentages, so I think it will be okay.