### PR TITLE
Remove bottom style

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -286,7 +286,7 @@
         width: 15em;
         font-size: 14px;
         right: 106%;
-        bottom: -36%;
+/*      bottom: -36%;*/
     }
 
 }


### PR DESCRIPTION
Commented out bottom style from tooltip text. This seems to fix the clipping problem.
Related to issue #66 .