### PR TITLE
fix bug with transferring mod powers to spectators that join after the game has started

### DIFF
--- a/client/src/config/globals.js
+++ b/client/src/config/globals.js
@@ -39,7 +39,8 @@ export const globals = {
         REVEAL_PLAYER: 'revealPlayer',
         CHANGE_NAME: 'changeName',
         START_GAME: 'startGame',
-        PLAYER_LEFT: 'playerLeft'
+        PLAYER_LEFT: 'playerLeft',
+        NEW_SPECTATOR: 'newSpectator'
     },
     USER_TYPES: {
         MODERATOR: 'moderator',

--- a/client/src/scripts/game.js
+++ b/client/src/scripts/game.js
@@ -157,6 +157,10 @@ function setClientSocketHandlers (stateBucket, gameStateRenderer, socket, timerW
         }
     });
 
+    socket.on(globals.EVENTS.NEW_SPECTATOR, (spectator) => {
+        stateBucket.currentGameState.spectators.push(spectator);
+    });
+
     socket.on(globals.EVENTS.PLAYER_LEFT, (player) => {
         removeStartGameFunctionalityIfPresent(gameStateRenderer);
         toast(player.name + ' has left!', 'error', false, true, 3);

--- a/server/config/globals.js
+++ b/server/config/globals.js
@@ -38,7 +38,8 @@ const globals = {
     EVENTS: {
         PLAYER_JOINED: 'playerJoined',
         PLAYER_LEFT: 'playerLeft',
-        SYNC_GAME_STATE: 'syncGameState'
+        SYNC_GAME_STATE: 'syncGameState',
+        NEW_SPECTATOR: 'newSpectator'
     },
     ENVIRONMENT: {
         LOCAL: 'local',

--- a/server/modules/GameManager.js
+++ b/server/modules/GameManager.js
@@ -284,6 +284,10 @@ class GameManager {
             );
             this.logger.trace('new spectator: ' + spectator.name);
             game.spectators.push(spectator);
+            this.namespace.in(game.accessCode).emit(
+                globals.EVENTS.NEW_SPECTATOR,
+                GameStateCurator.mapPerson(spectator)
+            );
             return Promise.resolve(spectator.cookie);
         }
     };


### PR DESCRIPTION
Fixes https://github.com/AlecM33/Werewolf/issues/84

Broadcast the event to the room and, on the client side, push the spectator to the array. Added unit tests for important joining functionality on the server-side. 