### PR TITLE
emit mod transfer events selectively

### DIFF
--- a/server/modules/SocketManager.js
+++ b/server/modules/SocketManager.js
@@ -85,7 +85,7 @@ class SocketManager {
                         if (!person) {
                             person = game.spectators.find((spectator) => spectator.id === args.personId);
                         }
-                        gameManager.transferModeratorPowers(game, person, this.logger);
+                        gameManager.transferModeratorPowers(game, person, namespace, this.logger);
                         break;
                     case EVENT_IDS.CHANGE_NAME:
                         gameManager.changeName(game, args.data, ackFn);


### PR DESCRIPTION
We were broadcasting a sync of the game state when the mod is transferred, causing a visible refresh, even for players that are not involved with the transfer. Now we emit the event selectively to the people involved in the mod transfer. 