### PR TITLE
don't emit killed event to person receiving mod powers

### DIFF
--- a/client/src/modules/game_state/states/Lobby.js
+++ b/client/src/modules/game_state/states/Lobby.js
@@ -76,7 +76,7 @@ export class Lobby {
 
     setSocketHandlers () {
         this.socket.on(globals.EVENT_IDS.PLAYER_JOINED, (player, gameIsFull) => {
-            toast(player.name + ' joined!', 'success', false, true, 'short');
+            toast(player.name + ' joined!', 'success', true, true, 'short');
             this.stateBucket.currentGameState.people.push(player);
             this.stateBucket.currentGameState.isFull = gameIsFull;
             this.populatePlayers();

--- a/client/src/styles/game.css
+++ b/client/src/styles/game.css
@@ -642,7 +642,7 @@ canvas {
     text-shadow: 0 3px 4px rgb(0 0 0 / 55%);
     margin: 5px 0 5px 25px;
     width: 65px;
-    height: 2px;
+    height: 25px;
 }
 
 #game-link:hover {

--- a/client/src/styles/game.css
+++ b/client/src/styles/game.css
@@ -642,6 +642,7 @@ canvas {
     text-shadow: 0 3px 4px rgb(0 0 0 / 55%);
     margin: 5px 0 5px 25px;
     width: 65px;
+    height: 2px;
 }
 
 #game-link:hover {

--- a/client/src/styles/game.css
+++ b/client/src/styles/game.css
@@ -382,7 +382,7 @@ h1 {
 #role-description {
     overflow: auto;
     position: absolute;
-    bottom: 8%;
+    bottom: 6%;
     left: 50%;
     transform: translate(-50%, 0);
     font-size: 15px;
@@ -785,6 +785,14 @@ canvas {
         font-size: 18px;
     }
 
+    #game-people-container {
+        padding: 5px;
+    }
+
+    #players-alive-label {
+        font-size: 20px;
+    }
+
     #client-name {
         font-size: 20px;
     }
@@ -810,8 +818,8 @@ canvas {
     /*    padding: 5px;*/
     /*}*/
 
-    .game-player-name {
-        font-size: 16px;
+    .game-player-name, .game-player-role {
+        font-size: 14px;
     }
 
     #game-timer {

--- a/server/modules/GameManager.js
+++ b/server/modules/GameManager.js
@@ -175,12 +175,13 @@ class GameManager {
             : accessCode;
     };
 
-    transferModeratorPowers = (game, person, namespace, logger) => {
+    transferModeratorPowers = (socket, game, person, namespace, logger) => {
         if (person && (person.out || person.userType === globals.USER_TYPES.SPECTATOR)) {
             logger.debug('game ' + game.accessCode + ': transferring mod powers to ' + person.name);
             if (game.moderator === person) {
                 person.userType = globals.USER_TYPES.MODERATOR;
                 this.namespace.to(person.socketId).emit(globals.EVENTS.SYNC_GAME_STATE);
+                socket.to(game.accessCode).emit(globals.EVENT_IDS.KILL_PLAYER, person.id);
             } else {
                 const oldModerator = game.moderator;
                 if (game.moderator.userType === globals.USER_TYPES.TEMPORARY_MODERATOR) {
@@ -204,17 +205,18 @@ class GameManager {
         }
     };
 
-    killPlayer = (game, person, namespace, logger) => {
+    killPlayer = (socket, game, person, namespace, logger) => {
         if (person && !person.out) {
             logger.debug('game ' + game.accessCode + ': killing player ' + person.name);
             if (person.userType !== globals.USER_TYPES.TEMPORARY_MODERATOR) {
                 person.userType = globals.USER_TYPES.KILLED_PLAYER;
             }
             person.out = true;
-            namespace.in(game.accessCode).emit(globals.EVENT_IDS.KILL_PLAYER, person.id);
             // temporary moderators will transfer their powers automatically to the first person they kill.
             if (game.moderator.userType === globals.USER_TYPES.TEMPORARY_MODERATOR) {
-                this.transferModeratorPowers(game, person, namespace, logger);
+                this.transferModeratorPowers(socket, game, person, namespace, logger);
+            } else {
+                namespace.in(game.accessCode).emit(globals.EVENT_IDS.KILL_PLAYER, person.id);
             }
         }
     };

--- a/server/modules/SocketManager.js
+++ b/server/modules/SocketManager.js
@@ -85,7 +85,7 @@ class SocketManager {
                         if (!person) {
                             person = game.spectators.find((spectator) => spectator.id === args.personId);
                         }
-                        gameManager.transferModeratorPowers(game, person, namespace, this.logger);
+                        gameManager.transferModeratorPowers(socket, game, person, namespace, this.logger);
                         break;
                     case EVENT_IDS.CHANGE_NAME:
                         gameManager.changeName(game, args.data, ackFn);

--- a/server/modules/SocketManager.js
+++ b/server/modules/SocketManager.js
@@ -75,7 +75,7 @@ class SocketManager {
                         gameManager.getTimeRemaining(game, socket);
                         break;
                     case EVENT_IDS.KILL_PLAYER:
-                        gameManager.killPlayer(game, game.people.find((person) => person.id === args.personId), namespace, this.logger);
+                        gameManager.killPlayer(socket, game, game.people.find((person) => person.id === args.personId), namespace, this.logger);
                         break;
                     case EVENT_IDS.REVEAL_PLAYER:
                         gameManager.revealPlayer(game, args.personId);

--- a/spec/unit/server/modules/GameManager_Spec.js
+++ b/spec/unit/server/modules/GameManager_Spec.js
@@ -9,7 +9,7 @@ const GameStateCurator = require('../../../../server/modules/GameStateCurator');
 const logger = require('../../../../server/modules/Logger.js')(false);
 
 describe('GameManager', () => {
-    let gameManager, namespace;
+    let gameManager, namespace, socket;
 
     beforeAll(() => {
         spyOn(logger, 'debug');
@@ -17,6 +17,7 @@ describe('GameManager', () => {
 
         const inObj = { emit: () => {} };
         namespace = { in: () => { return inObj; }, to: () => { return inObj; } };
+        socket = { id: '123', emit: () => {}, to: () => { return { emit: () => {} }; } };
         gameManager = new GameManager(logger, globals.ENVIRONMENT.PRODUCTION).getInstance();
         gameManager.setGameSocketNamespace(namespace);
     });
@@ -43,7 +44,7 @@ describe('GameManager', () => {
                 moderator.id,
                 new Date().toJSON()
             );
-            gameManager.transferModeratorPowers(game, personToTransferTo, namespace, logger);
+            gameManager.transferModeratorPowers(socket, game, personToTransferTo, namespace, logger);
 
             expect(game.moderator).toEqual(personToTransferTo);
             expect(personToTransferTo.userType).toEqual(USER_TYPES.MODERATOR);
@@ -69,7 +70,7 @@ describe('GameManager', () => {
                 new Date().toJSON()
             );
             game.spectators.push(personToTransferTo);
-            gameManager.transferModeratorPowers(game, personToTransferTo, namespace, logger);
+            gameManager.transferModeratorPowers(socket, game, personToTransferTo, namespace, logger);
 
             expect(game.moderator).toEqual(personToTransferTo);
             expect(personToTransferTo.userType).toEqual(USER_TYPES.MODERATOR);
@@ -95,7 +96,7 @@ describe('GameManager', () => {
                 tempMod.id,
                 new Date().toJSON()
             );
-            gameManager.transferModeratorPowers(game, personToTransferTo, namespace, logger);
+            gameManager.transferModeratorPowers(socket, game, personToTransferTo, namespace, logger);
 
             expect(game.moderator).toEqual(personToTransferTo);
             expect(personToTransferTo.userType).toEqual(USER_TYPES.MODERATOR);
@@ -120,7 +121,7 @@ describe('GameManager', () => {
                 tempMod.id,
                 new Date().toJSON()
             );
-            gameManager.transferModeratorPowers(game, personToTransferTo, namespace, logger);
+            gameManager.transferModeratorPowers(socket, game, personToTransferTo, namespace, logger);
 
             expect(game.moderator).toEqual(personToTransferTo);
             expect(personToTransferTo.userType).toEqual(USER_TYPES.MODERATOR);
@@ -146,7 +147,7 @@ describe('GameManager', () => {
                 mod.id,
                 new Date().toJSON()
             );
-            gameManager.killPlayer(game, player, namespace, logger);
+            gameManager.killPlayer(socket, game, player, namespace, logger);
 
             expect(player.out).toEqual(true);
             expect(player.userType).toEqual(USER_TYPES.KILLED_PLAYER);
@@ -169,11 +170,11 @@ describe('GameManager', () => {
                 tempMod.id,
                 new Date().toJSON()
             );
-            gameManager.killPlayer(game, tempMod, namespace, logger);
+            gameManager.killPlayer(socket, game, tempMod, namespace, logger);
 
             expect(tempMod.out).toEqual(true);
             expect(tempMod.userType).toEqual(USER_TYPES.TEMPORARY_MODERATOR);
-            expect(namespace.in().emit).toHaveBeenCalled();
+            expect(namespace.in().emit).not.toHaveBeenCalled();
             expect(gameManager.transferModeratorPowers).toHaveBeenCalled();
         });
     });

--- a/spec/unit/server/modules/GameManager_Spec.js
+++ b/spec/unit/server/modules/GameManager_Spec.js
@@ -24,6 +24,7 @@ describe('GameManager', () => {
 
     beforeEach(() => {
         spyOn(namespace, 'to').and.callThrough();
+        spyOn(socket, 'to').and.callThrough();
     });
 
     describe('#transferModerator', () => {
@@ -127,6 +128,7 @@ describe('GameManager', () => {
             expect(personToTransferTo.userType).toEqual(USER_TYPES.MODERATOR);
             expect(tempMod.userType).toEqual(USER_TYPES.MODERATOR);
             expect(namespace.to).toHaveBeenCalledOnceWith(personToTransferTo.socketId);
+            expect(socket.to).toHaveBeenCalledWith(game.accessCode);
         });
     });
 


### PR DESCRIPTION
Don't emit the "killed player" event to the person receiving moderator powers from the temporary mod, as this will immediately be overwritten by the event changing their view to the moderator's, causing a jarring visual effect on the front end. Now we only emit the event to sync their view to the moderators, while emitting the killed player event to everyone else.