### PR TITLE
fix bug with redundant play/pause events and with displaying current mod

### DIFF
--- a/client/src/modules/game_state/states/InProgress.js
+++ b/client/src/modules/game_state/states/InProgress.js
@@ -188,7 +188,8 @@ export class InProgress {
                     toast('You have been killed!', 'warning', true, true, 'medium');
                 } else {
                     toast(killedPlayer.name + ' was killed!', 'warning', true, true, 'medium');
-                    if (killedPlayer.userType === globals.USER_TYPES.MODERATOR) {
+                    if (killedPlayer.userType === globals.USER_TYPES.MODERATOR
+                        && this.stateBucket.currentGameState.client.userType !== globals.USER_TYPES.TEMPORARY_MODERATOR) {
                         SharedStateUtil.displayCurrentModerator(killedPlayer);
                     }
                 }

--- a/client/src/styles/game.css
+++ b/client/src/styles/game.css
@@ -21,8 +21,8 @@
     border-radius: 5px;
     color: #d7d7d7;
     background-color: #16141e;
-    width: fit-content;
-    padding: 0 20px;
+    padding: 0 10px;
+    width: 90%;
     margin-bottom: 0.5em;
 }
 
@@ -74,7 +74,7 @@
     flex-wrap: wrap;
     display: flex;
     width: 100%;
-    margin: 1em auto 140px auto;
+    margin: 0 auto 140px auto;
 }
 
 #game-state-container h2 {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "webpack --watch --config client/webpack/webpack-dev.config.js --mode=development",
     "start:dev": "NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && nodemon index.js",
     "start:dev:no-hot-reload": "NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && node index.js",
-    "start:dev:windows": "SET NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && nodemon index.js",
+    "start:dev:windows": "SET NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && nodemon index.js -- loglevel=debug",
     "start:dev:windows:no-hot-reload:debug": "SET NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && node --inspect index.js",
     "start:dev:windows:no-hot-reload": "SET NODE_ENV=development && webpack --config client/webpack/webpack-dev.config.js --mode=development && node index.js",
     "start": "NODE_ENV=production node index.js -- loglevel=debug",

--- a/server/modules/ServerTimer.js
+++ b/server/modules/ServerTimer.js
@@ -66,26 +66,29 @@ class ServerTimer {
     }
 
     stopTimer () {
-        this.logger.debug('STOPPING TIMER');
         if (this.ticking) {
+            this.logger.debug('STOPPING TIMER');
             clearTimeout(this.ticking);
+            this.ticking = null;
         }
     }
 
     resumeTimer () {
-        this.logger.debug('RESUMING TIMER FOR ' + this.currentTimeInMillis + 'ms');
-        this.start = Date.now();
-        this.totalTime = this.currentTimeInMillis;
-        const expected = Date.now() + this.tickInterval;
-        const instance = this;
-        this.ticking = setTimeout(function () {
-            stepFn(
-                instance,
-                expected
-            );
-        }, this.tickInterval);
+        if (!this.ticking) {
+            this.logger.debug('RESUMING TIMER FOR ' + this.currentTimeInMillis + 'ms');
+            this.start = Date.now();
+            this.totalTime = this.currentTimeInMillis;
+            const expected = Date.now() + this.tickInterval;
+            const instance = this;
+            this.ticking = setTimeout(function () {
+                stepFn(
+                    instance,
+                    expected
+                );
+            }, this.tickInterval);
 
-        return this.timesUpPromise;
+            return this.timesUpPromise;
+        }
     }
 }
 

--- a/server/modules/singletons/EventManager.js
+++ b/server/modules/singletons/EventManager.js
@@ -59,7 +59,7 @@ class EventManager {
             try {
                 messageComponents = message.split(';', 3);
                 if (messageComponents[messageComponents.length - 1] === this.instanceId) {
-                    this.logger.trace('Disregarding self-authored message');
+                    this.logger.debug('Disregarding self-authored message');
                     return;
                 }
                 args = JSON.parse(

--- a/spec/unit/server/modules/ServerTimer_Spec.js
+++ b/spec/unit/server/modules/ServerTimer_Spec.js
@@ -21,12 +21,11 @@ describe('ServerTimer', () => {
         serverTimer = new ServerTimer(1, 0, 10, logger);
         spyOn(global, 'clearTimeout');
         serverTimer.runTimer(false).then(() => {
-            fail();
+            serverTimer.stopTimer();
+            expect(clearTimeout).toHaveBeenCalledWith(serverTimer.ticking);
         }).catch((e) => {
             fail(e);
         });
-        serverTimer.stopTimer();
-        expect(clearTimeout).toHaveBeenCalledWith(serverTimer.ticking);
     });
 
     it('should stop and resume the timer', async () => {


### PR DESCRIPTION
Resuming the timer failed to check if the `ticking` variable was a non-null reference before re-assigning. I believe this was leading to weird behavior where the user could fire off play/pause events with a certain timing that would eventually fail to stop an instance of `ticking` (because there are multiple in memory) and cause the "end timer" event to be fired, even though it appears to be paused. We can see that below - the timer is displayed as paused at 17.3 seconds. The last message we received from the server was a pause timer event. Yet then we receive the end timer event and are prompted with such.

Stopping the timer now nulls `ticking` and resuming the timer will check if `ticking` is null before restoring a reference.

![image](https://user-images.githubusercontent.com/24642328/230740530-5d8c883e-125b-46da-876b-ab3fb12bb8fb.png)

We also fixed a bug where we were looking to display the current moderator when no such element existed in the DOM to populate with the data. This occurred right after a temp mod's powers were transferred away. Now we check if the client is a temp mod when processing the "kill player" event and, if so, do not attempt to update the content of that element (it will get updated when the client's view is synced as a part of the mod transfer event). 
