### PR TITLE
Remove 1 card requirement

### DIFF
--- a/client/src/modules/game_creation/GameCreationStepManager.js
+++ b/client/src/modules/game_creation/GameCreationStepManager.js
@@ -38,8 +38,6 @@ export class GameCreationStepManager {
                 forwardHandler: () => {
                     if (this.deckManager.getDeckSize() > 50) {
                         toast('Your deck is too large. The max is 50 cards.', 'error', true);
-                    } else if (this.deckManager.getDeckSize() < 1) {
-                        toast('You must add at least one card', 'error', true);
                     } else {
                         this.currentGame.deck = this.deckManager.deck.filter((card) => card.quantity > 0);
                         cancelCurrentToast();
@@ -366,7 +364,7 @@ function renderTimerStep (containerId, stepNumber, game, steps) {
     const hoursDiv = document.createElement('div');
     const hoursLabel = document.createElement('label');
     hoursLabel.setAttribute('for', 'game-hours');
-    hoursLabel.innerText = 'Hours (max 5)';
+    hoursLabel.innerText = 'Hours';
     const hours = document.createElement('input');
     hours.addEventListener('keyup', steps[stepNumber].forwardHandler);
     setAttributes(hours, { type: 'number', id: 'game-hours', name: 'game-hours', min: '0', max: '5', value: game.timerParams?.hours });
@@ -414,7 +412,7 @@ function renderReviewAndCreateStep (containerId, stepNumber, game, deckManager) 
         '</div>' +
         '<div>' +
             "<label id='roles-option-label' for='roles-option'>Game Deck:</label>" +
-            "<div id='roles-option' class='review-option'></div>" +
+            "<div id='roles-option' class='review-option'>No cards selected.</div>" +
         '</div>';
 
     div.querySelector('#test-game').innerText = game.isTestGame ? 'Yes' : 'No';

--- a/client/src/modules/game_creation/GameCreationStepManager.js
+++ b/client/src/modules/game_creation/GameCreationStepManager.js
@@ -435,6 +435,10 @@ function renderReviewAndCreateStep (containerId, stepNumber, game, deckManager) 
         div.querySelector('#timer-option').innerText = 'untimed';
     }
 
+    if (game.deck.length > 0) {
+        div.querySelector('#roles-option').innerText = '';
+    }
+
     for (const card of game.deck) {
         const roleEl = document.createElement('div');
         roleEl.innerText = card.quantity + 'x ' + card.role;

--- a/client/src/modules/game_state/states/Lobby.js
+++ b/client/src/modules/game_state/states/Lobby.js
@@ -81,8 +81,6 @@ export class Lobby {
             roleEditPrompt.querySelector('#save-role-changes-button').addEventListener('click', () => {
                 if (this.gameCreationStepManager.deckManager.getDeckSize() > 50) {
                     toast('Your deck is too large. The max is 50 cards.', 'error', true);
-                } else if (this.gameCreationStepManager.deckManager.getDeckSize() < 1) {
-                    toast('You must add at least one card', 'error', true);
                 } else {
                     document.querySelector('#mid-game-role-editor')?.remove();
                     document.querySelector('#role-edit-container-background')?.remove();

--- a/server/model/Game.js
+++ b/server/model/Game.js
@@ -27,7 +27,9 @@ class Game {
         this.previousModeratorId = null;
         this.createTime = createTime;
         this.timerParams = timerParams;
-        this.isStartable = (this.gameSize === 1 && !this.hasDedicatedModerator) || isTestGame;
+        this.isStartable = (this.gameSize === 1 && !this.hasDedicatedModerator)
+            || (this.gameSize === 0 && this.hasDedicatedModerator)
+            || isTestGame;
         this.timeRemaining = null;
     }
 }

--- a/server/model/GameCreationRequest.js
+++ b/server/model/GameCreationRequest.js
@@ -31,7 +31,7 @@ class GameCreationRequest {
     };
 
     static deckIsValid = (deck) => {
-        if (Array.isArray(deck) && deck.length > 0) {
+        if (Array.isArray(deck)) {
             for (const entry of deck) {
                 if (entry !== null
                     && typeof entry === 'object'
@@ -45,7 +45,7 @@ class GameCreationRequest {
                     && entry.description.length <= globals.MAX_CUSTOM_ROLE_DESCRIPTION_LENGTH
                     && (!entry.custom || typeof entry.custom === 'boolean')
                     && typeof entry.quantity === 'number'
-                    && entry.quantity >= 1
+                    && entry.quantity >= 0
                     && entry.quantity <= 50
                 ) {
                     continue;


### PR DESCRIPTION
For max flexibility, allow user to create a game not having added any cards. Since you can do this in the lobby now, a user may just want to create the room with a blank slate and build the game as people join.