### PR TITLE
manually close socket when window is unloaded

### DIFF
--- a/client/src/modules/page_handlers/gameHandler.js
+++ b/client/src/modules/page_handlers/gameHandler.js
@@ -20,7 +20,7 @@ import { Ended } from '../game_state/states/Ended.js';
 export const gameHandler = (socket, window, gameDOM) => {
     window.onunload = () => {
         socket.close();
-    }
+    };
     document.body.innerHTML = gameDOM + document.body.innerHTML;
     injectNavbar();
     const connectionHandler = () => {

--- a/client/src/modules/page_handlers/gameHandler.js
+++ b/client/src/modules/page_handlers/gameHandler.js
@@ -18,6 +18,9 @@ import { InProgress } from '../game_state/states/InProgress.js';
 import { Ended } from '../game_state/states/Ended.js';
 
 export const gameHandler = (socket, window, gameDOM) => {
+    window.onunload = () => {
+        socket.close();
+    }
     document.body.innerHTML = gameDOM + document.body.innerHTML;
     injectNavbar();
     const connectionHandler = () => {


### PR DESCRIPTION
we were not closing the connection when the window is unloaded. This could lead to behavior in certain browsers where, if we use   back/forward navigation, a cached page is served and the socket connection is not immediately restored. There's no visual feedback this has occurred - socket events will just hang indefinitely until eventually the disconnect is detected and the client reconnects. 