### PR TITLE
Fix logic that determines if a game is startable when first constructed

### DIFF
--- a/server/model/Game.js
+++ b/server/model/Game.js
@@ -9,8 +9,7 @@ class Game {
         hasDedicatedModerator,
         originalModeratorId,
         createTime,
-        timerParams = null,
-        isTestGame = false
+        timerParams = null
     ) {
         this.accessCode = accessCode;
         this.status = status;
@@ -27,9 +26,6 @@ class Game {
         this.previousModeratorId = null;
         this.createTime = createTime;
         this.timerParams = timerParams;
-        this.isStartable = (this.gameSize === 1 && !this.hasDedicatedModerator)
-            || (this.gameSize === 0 && this.hasDedicatedModerator)
-            || isTestGame;
         this.timeRemaining = null;
     }
 }

--- a/server/modules/singletons/GameManager.js
+++ b/server/modules/singletons/GameManager.js
@@ -91,10 +91,12 @@ class GameManager {
                 req.hasDedicatedModerator,
                 moderator.id,
                 new Date().toJSON(),
-                req.timerParams,
-                req.isTestGame
+                req.timerParams
             );
             newGame.people = initializePeopleForGame(req.deck, moderator, this.shuffle, req.isTestGame, newGame.gameSize);
+            newGame.isStartable = newGame.people.filter(person => person.userType === USER_TYPES.PLAYER
+                || person.userType === USER_TYPES.TEMPORARY_MODERATOR
+                || person.userType === USER_TYPES.BOT).length === newGame.gameSize;
             await this.eventManager.publisher.set(newAccessCode, JSON.stringify(newGame), {
                 EX: PRIMITIVES.STALE_GAME_SECONDS
             });

--- a/spec/unit/server/modules/Events_Spec.js
+++ b/spec/unit/server/modules/Events_Spec.js
@@ -42,6 +42,9 @@ describe('Events', () => {
             new Date().toJSON(),
             null
         );
+        game.isStartable = game.people.filter(person => person.userType === USER_TYPES.PLAYER
+            || person.userType === USER_TYPES.TEMPORARY_MODERATOR
+            || person.userType === USER_TYPES.BOT).length === game.gameSize;
         spyOn(namespace, 'to').and.callThrough();
         spyOn(namespace, 'in').and.callThrough();
         spyOn(socket, 'to').and.callThrough();


### PR DESCRIPTION
There was a small bug in the logic that determined whether a game can be started as soon as it is constructed. Specifically, if the game has a temporary moderator, and the deck has 0 cards, we were still saying the game can be started, which is obviously incorrect (we have no card to deal to the temporary moderator). Now we just check if the count of users who get dealt a card is equal to the game size.