### PR TITLE
Spectator bugfixes

### DIFF
--- a/client/src/config/globals.js
+++ b/client/src/config/globals.js
@@ -106,6 +106,6 @@ export const IN_PROGRESS_EVENTS = function () {
         EVENT_IDS.KILL_PLAYER,
         EVENT_IDS.REVEAL_PLAYER,
         EVENT_IDS.ADD_SPECTATOR,
-        EVENT_IDS.KICK_PERSON,
+        EVENT_IDS.KICK_PERSON
     ];
 };

--- a/client/src/config/globals.js
+++ b/client/src/config/globals.js
@@ -105,6 +105,7 @@ export const IN_PROGRESS_EVENTS = function () {
     return [
         EVENT_IDS.KILL_PLAYER,
         EVENT_IDS.REVEAL_PLAYER,
-        EVENT_IDS.ADD_SPECTATOR
+        EVENT_IDS.ADD_SPECTATOR,
+        EVENT_IDS.KICK_PERSON,
     ];
 };

--- a/client/src/modules/game_state/states/InProgress.js
+++ b/client/src/modules/game_state/states/InProgress.js
@@ -35,11 +35,13 @@ export class InProgress {
                 break;
             case USER_TYPES.MODERATOR:
                 document.getElementById('transfer-mod-prompt').innerHTML = HTMLFragments.TRANSFER_MOD_MODAL;
+                document.getElementById('player-options-prompt').innerHTML = HTMLFragments.PLAYER_OPTIONS_MODAL;
                 this.container.innerHTML = HTMLFragments.MODERATOR_GAME_VIEW;
                 this.renderModeratorView();
                 break;
             case USER_TYPES.TEMPORARY_MODERATOR:
                 document.getElementById('transfer-mod-prompt').innerHTML = HTMLFragments.TRANSFER_MOD_MODAL;
+                document.getElementById('player-options-prompt').innerHTML = HTMLFragments.PLAYER_OPTIONS_MODAL;
                 this.container.innerHTML = HTMLFragments.TEMP_MOD_GAME_VIEW;
                 this.renderTempModView();
                 break;
@@ -257,6 +259,14 @@ export class InProgress {
             }
         });
 
+        this.socket.on(EVENT_IDS.KICK_PERSON, (kickedId, gameIsStartable) => {
+            if (kickedId === this.stateBucket.currentGameState.client.id) {
+                window.location = '/?message=' + encodeURIComponent('You were kicked by the moderator.');
+            } else {
+                this.handleSpectatorExiting(kickedId);
+            }
+        });
+
         if (this.stateBucket.currentGameState.timerParams) {
             if (this.stateBucket.timerWorker) {
                 this.stateBucket.timerWorker.terminate();
@@ -387,6 +397,31 @@ export class InProgress {
                 : 'game-player-list';
 
             document.getElementById(playerListContainerId).appendChild(playerEl);
+        }
+    }
+
+    handleSpectatorExiting (id) {
+        const index = this.stateBucket.currentGameState.people.findIndex(person => person.id === id);
+        if (index >= 0) {
+            this.stateBucket.currentGameState.people
+                .splice(index, 1);
+        }
+        SharedStateUtil.setNumberOfSpectators(
+            this.stateBucket.currentGameState.people.filter(p => p.userType === USER_TYPES.SPECTATOR).length,
+            document.getElementById('spectator-count')
+        );
+        if ((
+            this.stateBucket.currentGameState.client.userType === USER_TYPES.MODERATOR
+            || this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR
+        )
+        ) {
+            toast(
+                'Spectator kicked.',
+                'success',
+                true,
+                true,
+                'short'
+            );
         }
     }
 

--- a/client/src/modules/game_state/states/InProgress.js
+++ b/client/src/modules/game_state/states/InProgress.js
@@ -410,11 +410,8 @@ export class InProgress {
             this.stateBucket.currentGameState.people.filter(p => p.userType === USER_TYPES.SPECTATOR).length,
             document.getElementById('spectator-count')
         );
-        if ((
-            this.stateBucket.currentGameState.client.userType === USER_TYPES.MODERATOR
-            || this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR
-        )
-        ) {
+        if (this.stateBucket.currentGameState.client.userType === USER_TYPES.MODERATOR
+            || this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR) {
             toast(
                 'Spectator kicked.',
                 'success',

--- a/client/src/modules/game_state/states/Lobby.js
+++ b/client/src/modules/game_state/states/Lobby.js
@@ -1,12 +1,12 @@
-import {QRCode} from '../../third_party/qrcode.js';
-import {toast} from '../../front_end_components/Toast.js';
-import {EVENT_IDS, PRIMITIVES, SOCKET_EVENTS, USER_TYPE_ICONS, USER_TYPES} from '../../../config/globals.js';
-import {HTMLFragments} from '../../front_end_components/HTMLFragments.js';
-import {Confirmation} from '../../front_end_components/Confirmation.js';
-import {SharedStateUtil} from './shared/SharedStateUtil.js';
-import {GameCreationStepManager} from '../../game_creation/GameCreationStepManager.js';
-import {DeckStateManager} from '../../game_creation/DeckStateManager.js';
-import {hiddenMenus} from '../../../view_templates/CreateTemplate.js';
+import { QRCode } from '../../third_party/qrcode.js';
+import { toast } from '../../front_end_components/Toast.js';
+import { EVENT_IDS, PRIMITIVES, SOCKET_EVENTS, USER_TYPE_ICONS, USER_TYPES } from '../../../config/globals.js';
+import { HTMLFragments } from '../../front_end_components/HTMLFragments.js';
+import { Confirmation } from '../../front_end_components/Confirmation.js';
+import { SharedStateUtil } from './shared/SharedStateUtil.js';
+import { GameCreationStepManager } from '../../game_creation/GameCreationStepManager.js';
+import { DeckStateManager } from '../../game_creation/DeckStateManager.js';
+import { hiddenMenus } from '../../../view_templates/CreateTemplate.js';
 
 export class Lobby {
     constructor (containerId, stateBucket, socket) {

--- a/client/src/modules/game_state/states/Lobby.js
+++ b/client/src/modules/game_state/states/Lobby.js
@@ -1,12 +1,12 @@
-import { QRCode } from '../../third_party/qrcode.js';
-import { toast } from '../../front_end_components/Toast.js';
-import { EVENT_IDS, PRIMITIVES, SOCKET_EVENTS, USER_TYPE_ICONS, USER_TYPES } from '../../../config/globals.js';
-import { HTMLFragments } from '../../front_end_components/HTMLFragments.js';
-import { Confirmation } from '../../front_end_components/Confirmation.js';
-import { SharedStateUtil } from './shared/SharedStateUtil.js';
-import { GameCreationStepManager } from '../../game_creation/GameCreationStepManager.js';
-import { DeckStateManager } from '../../game_creation/DeckStateManager.js';
-import { hiddenMenus } from '../../../view_templates/CreateTemplate.js';
+import {QRCode} from '../../third_party/qrcode.js';
+import {toast} from '../../front_end_components/Toast.js';
+import {EVENT_IDS, PRIMITIVES, SOCKET_EVENTS, USER_TYPE_ICONS, USER_TYPES} from '../../../config/globals.js';
+import {HTMLFragments} from '../../front_end_components/HTMLFragments.js';
+import {Confirmation} from '../../front_end_components/Confirmation.js';
+import {SharedStateUtil} from './shared/SharedStateUtil.js';
+import {GameCreationStepManager} from '../../game_creation/GameCreationStepManager.js';
+import {DeckStateManager} from '../../game_creation/DeckStateManager.js';
+import {hiddenMenus} from '../../../view_templates/CreateTemplate.js';
 
 export class Lobby {
     constructor (containerId, stateBucket, socket) {
@@ -316,11 +316,8 @@ export class Lobby {
             document.getElementById('spectator-count')
         );
         this.populatePlayers();
-        if ((
-            this.stateBucket.currentGameState.client.userType === USER_TYPES.MODERATOR
-            || this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR
-        )
-        ) {
+        if (this.stateBucket.currentGameState.client.userType === USER_TYPES.MODERATOR
+            || this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR) {
             toast(
                 event === EVENT_IDS.LEAVE_ROOM ? 'A player left.' : 'Player kicked.',
                 event === EVENT_IDS.LEAVE_ROOM ? 'warning' : 'success',

--- a/server/modules/Events.js
+++ b/server/modules/Events.js
@@ -23,7 +23,6 @@ const Events = [
             const toBeClearedIndex = game.people.findIndex(
                 (person) => person.id === socketArgs.personId && person.assigned === true
             );
-            console.log(game.people[toBeClearedIndex])
             if (toBeClearedIndex >= 0) {
                 game.people.splice(toBeClearedIndex, 1);
                 game.isStartable = vars.gameManager.isGameStartable(game);

--- a/server/modules/Events.js
+++ b/server/modules/Events.js
@@ -23,6 +23,7 @@ const Events = [
             const toBeClearedIndex = game.people.findIndex(
                 (person) => person.id === socketArgs.personId && person.assigned === true
             );
+            console.log(game.people[toBeClearedIndex])
             if (toBeClearedIndex >= 0) {
                 game.people.splice(toBeClearedIndex, 1);
                 game.isStartable = vars.gameManager.isGameStartable(game);


### PR DESCRIPTION
Fixes #186 and #187. There were two simple causes for these issues:

- we were not adding the "player options" modal to the DOM for the "in progress" game state. This prevented us from being able to bring up this modal when clicking a spectator's kabab menu when the game is in progress.
- In the front-end logic, we simply did not handle the fact that spectators can be kicked after the game has been started (probably because we noted players cannot be kicked during the game, but forgot to preserve the functionality for spectators). Specifically we forgot to add the event handling - we fired off the event to the server, but did not process the resulting state change. Just adding that socket handler to the InProgress module fixed the problem.