### PR TITLE
Fix bug where we incorrectly added a user as a player instead of a spectator

### DIFF
--- a/server/modules/singletons/GameManager.js
+++ b/server/modules/singletons/GameManager.js
@@ -191,7 +191,7 @@ class GameManager {
             && game.people.filter(person => person.userType === USER_TYPES.SPECTATOR).length === PRIMITIVES.MAX_SPECTATORS
         ) {
             return Promise.reject({ status: 400, reason: 'There are too many people already spectating.' });
-        } else if (joinAsSpectator || this.isGameStartable(game) || game.status === STATUS.IN_PROGRESS) {
+        } else if (joinAsSpectator || this.isGameStartable(game)) {
             return await addSpectator(game, name, this.logger, this.namespace, this.eventManager, this.instanceId, this.refreshGame);
         }
         let moderator, newPlayer;
@@ -328,9 +328,9 @@ class GameManager {
     }
 
     isGameStartable = (game) => {
-        return game.people.filter(person => person.userType === USER_TYPES.PLAYER
+        return game.status !== STATUS.IN_PROGRESS && (game.people.filter(person => person.userType === USER_TYPES.PLAYER
             || person.userType === USER_TYPES.TEMPORARY_MODERATOR
-            || person.userType === USER_TYPES.BOT).length === game.gameSize;
+            || person.userType === USER_TYPES.BOT).length === game.gameSize);
     }
 
     findPersonByField = (game, fieldName, value) => {

--- a/server/modules/singletons/GameManager.js
+++ b/server/modules/singletons/GameManager.js
@@ -191,7 +191,7 @@ class GameManager {
             && game.people.filter(person => person.userType === USER_TYPES.SPECTATOR).length === PRIMITIVES.MAX_SPECTATORS
         ) {
             return Promise.reject({ status: 400, reason: 'There are too many people already spectating.' });
-        } else if (joinAsSpectator || this.isGameStartable(game)) {
+        } else if (joinAsSpectator || this.isGameStartable(game) || game.status === STATUS.IN_PROGRESS) {
             return await addSpectator(game, name, this.logger, this.namespace, this.eventManager, this.instanceId, this.refreshGame);
         }
         let moderator, newPlayer;
@@ -328,9 +328,9 @@ class GameManager {
     }
 
     isGameStartable = (game) => {
-        return game.status !== STATUS.IN_PROGRESS && (game.people.filter(person => person.userType === USER_TYPES.PLAYER
+        return game.people.filter(person => person.userType === USER_TYPES.PLAYER
             || person.userType === USER_TYPES.TEMPORARY_MODERATOR
-            || person.userType === USER_TYPES.BOT).length === game.gameSize);
+            || person.userType === USER_TYPES.BOT).length === game.gameSize;
     }
 
     findPersonByField = (game, fieldName, value) => {

--- a/server/modules/singletons/GameManager.js
+++ b/server/modules/singletons/GameManager.js
@@ -191,7 +191,7 @@ class GameManager {
             && game.people.filter(person => person.userType === USER_TYPES.SPECTATOR).length === PRIMITIVES.MAX_SPECTATORS
         ) {
             return Promise.reject({ status: 400, reason: 'There are too many people already spectating.' });
-        } else if (joinAsSpectator || this.isGameStartable(game)) {
+        } else if (joinAsSpectator || this.isGameStartable(game) || game.status === STATUS.IN_PROGRESS) {
             return await addSpectator(game, name, this.logger, this.namespace, this.eventManager, this.instanceId, this.refreshGame);
         }
         let moderator, newPlayer;


### PR DESCRIPTION
There was a pretty niche scenario where a user could join a game that is already in-progress and get assigned the role of "Player." This happened when the game was started with a Temporary Moderator, but then someone was killed and we established a Dedicated Mod. In that case, the server failed to detect the state of the game correctly and assumed they should be a Player. 

To fix this, we added a check for the status being "In Progess" as a condition where we should add any new joiners as spectators.