### PR TITLE
Remove unload event

### DIFF
--- a/client/src/modules/page_handlers/gameHandler.js
+++ b/client/src/modules/page_handlers/gameHandler.js
@@ -62,7 +62,7 @@ export const gameHandler = (socket, window, gameDOM) => {
 
                 socket.on('disconnect', (reason) => {
                     toast('Disconnected. Attempting reconnect...', 'error', true, false);
-                    if (reason === "io client disconnect") { // see https://socket.io/docs/v4/client-api/#event-disconnect
+                    if (reason === 'io client disconnect') { // see https://socket.io/docs/v4/client-api/#event-disconnect
                         socket.connect();
                     }
                 });

--- a/client/src/modules/page_handlers/gameHandler.js
+++ b/client/src/modules/page_handlers/gameHandler.js
@@ -62,7 +62,7 @@ export const gameHandler = (socket, window, gameDOM) => {
 
                 socket.on('disconnect', (reason) => {
                     toast('Disconnected. Attempting reconnect...', 'error', true, false);
-                    if (reason === "io client disconnect") {
+                    if (reason === "io client disconnect") { // see https://socket.io/docs/v4/client-api/#event-disconnect
                         socket.connect();
                     }
                 });

--- a/client/src/modules/page_handlers/gameHandler.js
+++ b/client/src/modules/page_handlers/gameHandler.js
@@ -18,7 +18,7 @@ import { InProgress } from '../game_state/states/InProgress.js';
 import { Ended } from '../game_state/states/Ended.js';
 
 export const gameHandler = (socket, window, gameDOM) => {
-    window.onunload = () => {
+    window.onpagehide = () => {
         socket.close();
     };
     document.body.innerHTML = gameDOM + document.body.innerHTML;
@@ -60,8 +60,11 @@ export const gameHandler = (socket, window, gameDOM) => {
                     toast(err, 'error', true, false);
                 });
 
-                socket.on('disconnect', () => {
+                socket.on('disconnect', (reason) => {
                     toast('Disconnected. Attempting reconnect...', 'error', true, false);
+                    if (reason === "io client disconnect") {
+                        socket.connect();
+                    }
                 });
                 setClientSocketHandlers(stateBucket, socket);
                 resolve();


### PR DESCRIPTION
The unload event is deprecated and can interfere with the back forward cache. See https://web.dev/articles/bfcache?utm_source=lighthouse&utm_medium=devtools#never_use_the_unload_event

Thus we use the page hide event instead to manually close the socket. Then, when the user uses forward nav for example, we need to manually reconnect according to the socket.io docs.

Example of being able to use back and forward nav and re-establishing a socket connection

https://github.com/AlecM33/Werewolf/assets/24642328/449825cd-0dbe-4d5d-adaf-a6fc16b64b45

