### PR TITLE
add option to give all players permission to kill/reveal

### DIFF
--- a/client/src/model/Game.js
+++ b/client/src/model/Game.js
@@ -5,7 +5,8 @@ export class Game {
         hasDedicatedModerator,
         moderatorName,
         timerParams = null,
-        isTestGame = false
+        isTestGame = false,
+        hasAllKillPermission = false
     ) {
         this.deck = deck;
         this.hasTimer = hasTimer;
@@ -13,5 +14,6 @@ export class Game {
         this.hasDedicatedModerator = hasDedicatedModerator;
         this.moderatorName = moderatorName;
         this.isTestGame = isTestGame;
+        this.hasAllKillPermission = hasAllKillPermission;
     }
 }

--- a/client/src/modules/front_end_components/HTMLFragments.js
+++ b/client/src/modules/front_end_components/HTMLFragments.js
@@ -43,6 +43,16 @@ export const HTMLFragments = {
                 <option value="no" selected>No</option>
                 <option value="yes">Yes</option>
             </select>
+        </div>
+        <div>
+            <label for="all-kill-permission">
+                Give all players kill/reveal permission?
+                <span id="kill-permission-help" class="help-icon" title="If evil players need to kill on the very first night (AKA &quot;Night 0&quot;), and there is no dedicated moderator, enable this to give all players the ability to kill and reveal players.">?</span>
+            </label>
+            <select id="all-kill-permission">
+                <option value="no" selected>No</option>
+                <option value="yes">Yes</option>
+            </select>
         </div>`,
     START_GAME_PROMPT:
     `<button id='edit-roles-button'>Edit Roles</button>

--- a/client/src/modules/game_creation/GameCreationStepManager.js
+++ b/client/src/modules/game_creation/GameCreationStepManager.js
@@ -122,7 +122,8 @@ export class GameCreationStepManager {
                                     this.currentGame.hasDedicatedModerator,
                                     this.currentGame.moderatorName,
                                     this.currentGame.timerParams,
-                                    this.currentGame.isTestGame
+                                    this.currentGame.isTestGame,
+                                    this.currentGame.hasAllKillPermission
                                 )
                             )
                         }).catch((e) => {
@@ -365,6 +366,12 @@ function renderNameStep (containerId, step, game, steps) {
         game.isTestGame = testGameInput.value === 'yes';
     };
     testGameInput.value = game.isTestGame ? 'yes' : 'no';
+
+    const killPermissionInput = document.getElementById('all-kill-permission');
+    killPermissionInput.onchange = () => {
+        game.hasAllKillPermission = killPermissionInput.value === 'yes';
+    };
+    killPermissionInput.value = game.hasAllKillPermission ? 'yes' : 'no';
 }
 
 function renderModerationTypeStep (game, containerId, stepNumber) {
@@ -420,16 +427,20 @@ function renderReviewAndCreateStep (containerId, stepNumber, game, deckManager) 
             "<div id='mod-name' class='review-option'></div>" +
         '</div>' +
         '<div>' +
-            "<label for='test-game'>Populate game with bots?</label>" +
-            "<div id='test-game' class='review-option'></div>" +
-        '</div>' +
-        '<div>' +
             "<label for='mod-option'>Moderation:</label>" +
             "<div id='mod-option' class='review-option'></div>" +
         '</div>' +
         '<div>' +
             "<label for='timer-option'>Timer:</label>" +
             "<div id='timer-option' class='review-option'></div>" +
+        '</div>' +
+        '<div>' +
+            "<label for='test-game'>Populate game with bots?</label>" +
+            "<div id='test-game' class='review-option'></div>" +
+        '</div>' +
+        '<div>' +
+            "<label for='kill-permission-option'>All players can kill/reveal?</label>" +
+            "<div id='kill-permission-option' class='review-option'></div>" +
         '</div>' +
         '<div>' +
             "<label id='roles-option-label' for='roles-option'>Game Deck:</label>" +
@@ -441,6 +452,8 @@ function renderReviewAndCreateStep (containerId, stepNumber, game, deckManager) 
     div.querySelector('#mod-option').innerText = game.hasDedicatedModerator
         ? "Dedicated Moderator - don't deal me a card."
         : 'Temporary Moderator - deal me into the game.';
+
+    div.querySelector('#kill-permission-option').innerText = game.hasAllKillPermission ? 'Yes' : 'No';
 
     if (game.hasTimer) {
         const formattedHours = game.timerParams.hours !== null

--- a/client/src/modules/game_state/states/InProgress.js
+++ b/client/src/modules/game_state/states/InProgress.js
@@ -112,7 +112,7 @@ export class InProgress {
     }
 
     renderPlayersWithNoRoleInformationUnlessRevealed (tempMod = false) {
-        if (tempMod) {
+        if (tempMod || this.stateBucket.currentGameState.hasAllKillPermission) {
             this.removePlayerListEventListeners();
         }
         document.querySelectorAll('.game-player').forEach((el) => el.remove());
@@ -122,7 +122,7 @@ export class InProgress {
         const modType = tempMod
             ? this.stateBucket.currentGameState.people.find(person =>
                 person.id === this.stateBucket.currentGameState.currentModeratorId).userType
-            : null;
+            : (this.stateBucket.currentGameState.hasAllKillPermission ? USER_TYPES.TEMPORARY_MODERATOR : null);
         this.renderGroupOfPlayers(
             this.stateBucket.currentGameState.people.filter(
                 p => (p.userType !== USER_TYPES.MODERATOR && p.userType !== USER_TYPES.SPECTATOR)
@@ -390,7 +390,15 @@ export class InProgress {
             } else if (!player.out && moderatorType) {
                 killPlayerHandlers[player.id] = () => {
                     Confirmation('Kill \'' + player.name + '\'?', () => {
-                        if (this.stateBucket.currentGameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR) {
+                        const gameState = this.stateBucket.currentGameState;
+                        const hasTempMod = gameState.people.some(
+                            p => p.id === gameState.currentModeratorId
+                                && !p.out
+                                && (p.userType === USER_TYPES.TEMPORARY_MODERATOR || p.userType === USER_TYPES.PLAYER)
+                        );
+                        const noOneKilledYet = !gameState.people.some(p => p.killed);
+                        if (gameState.client.userType === USER_TYPES.TEMPORARY_MODERATOR
+                            || (gameState.hasAllKillPermission && hasTempMod && noOneKilledYet)) {
                             socket.emit(SOCKET_EVENTS.IN_GAME_MESSAGE, EVENT_IDS.ASSIGN_DEDICATED_MOD, accessCode, { personId: player.id });
                         } else {
                             socket.emit(SOCKET_EVENTS.IN_GAME_MESSAGE, EVENT_IDS.KILL_PLAYER, accessCode, { personId: player.id });

--- a/client/src/styles/create.css
+++ b/client/src/styles/create.css
@@ -331,11 +331,11 @@ option {
     width: 100%;
 }
 
-#step-4 div:nth-child(2) {
+#step-4 div:nth-child(2), #step-4 div:nth-child(3) {
     margin-top: 25px;
 }
 
-#step-4 label[for="test-game"] {
+#step-4 label[for="test-game"], #step-4 label[for="all-kill-permission"] {
     display: block;
     margin-bottom: 10px;
 }
@@ -671,6 +671,43 @@ input[type="number"] {
     border-radius: 5px;
     margin: 0.5em 0;
     align-self: flex-start;
+}
+
+.help-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background-color: #555;
+    color: #fff;
+    font-size: 12px;
+    font-weight: bold;
+    cursor: pointer;
+    margin-left: 5px;
+    vertical-align: middle;
+    user-select: none;
+    position: relative;
+}
+
+.help-icon:hover::after {
+    content: attr(title);
+    position: absolute;
+    bottom: 130%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: normal;
+    white-space: normal;
+    width: 250px;
+    text-align: center;
+    z-index: 100;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
 }
 
 @keyframes fade-in {

--- a/client/src/styles/create.css
+++ b/client/src/styles/create.css
@@ -695,8 +695,8 @@ input[type="number"] {
     content: attr(title);
     position: absolute;
     bottom: 130%;
-    left: 50%;
-    transform: translateX(-50%);
+    right: 0;
+    transform: none;
     background-color: #333;
     color: #fff;
     padding: 8px 12px;
@@ -705,6 +705,7 @@ input[type="number"] {
     font-weight: normal;
     white-space: normal;
     width: 250px;
+    max-width: 80vw;
     text-align: center;
     z-index: 100;
     box-shadow: 0 2px 8px rgba(0,0,0,0.4);

--- a/client/src/styles/game.css
+++ b/client/src/styles/game.css
@@ -899,7 +899,7 @@ canvas {
     width: 18px;
 }
 
-#game-player-list > .game-player.killed::after {
+#game-player-list > .game-player.killed:not(:has(.player-action-buttons))::after {
     content: '\01F480';
     font-size: 24px;
     margin-left: 1em;

--- a/server/model/Game.js
+++ b/server/model/Game.js
@@ -9,7 +9,8 @@ class Game {
         hasDedicatedModerator,
         originalModeratorId,
         createTime,
-        timerParams = null
+        timerParams = null,
+        hasAllKillPermission = false
     ) {
         this.accessCode = accessCode;
         this.status = status;
@@ -27,6 +28,7 @@ class Game {
         this.createTime = createTime;
         this.timerParams = timerParams;
         this.timeRemaining = null;
+        this.hasAllKillPermission = hasAllKillPermission;
     }
 }
 

--- a/server/model/GameCreationRequest.js
+++ b/server/model/GameCreationRequest.js
@@ -7,7 +7,8 @@ class GameCreationRequest {
         timerParams,
         moderatorName,
         hasDedicatedModerator,
-        isTestGame
+        isTestGame,
+        hasAllKillPermission
     ) {
         this.deck = deck;
         this.hasTimer = hasTimer;
@@ -15,10 +16,11 @@ class GameCreationRequest {
         this.moderatorName = moderatorName;
         this.hasDedicatedModerator = hasDedicatedModerator;
         this.isTestGame = isTestGame;
+        this.hasAllKillPermission = hasAllKillPermission;
     }
 
     static validate = (gameParams) => {
-        const expectedKeys = ['deck', 'hasTimer', 'timerParams', 'moderatorName', 'hasDedicatedModerator', 'isTestGame'];
+        const expectedKeys = ['deck', 'hasTimer', 'timerParams', 'moderatorName', 'hasDedicatedModerator', 'isTestGame', 'hasAllKillPermission'];
         if (gameParams === null
             || typeof gameParams !== 'object'
             || expectedKeys.some((key) => !Object.keys(gameParams).includes(key))
@@ -78,6 +80,7 @@ function valid (gameParams) {
     return typeof gameParams.hasTimer === 'boolean'
         && typeof gameParams.isTestGame === 'boolean'
         && typeof gameParams.hasDedicatedModerator === 'boolean'
+        && typeof gameParams.hasAllKillPermission === 'boolean'
         && typeof gameParams.moderatorName === 'string'
         && gameParams.moderatorName.length > 0
         && gameParams.moderatorName.length <= 30

--- a/server/modules/Events.js
+++ b/server/modules/Events.js
@@ -91,6 +91,17 @@ async function handleTimerCommand (timerEventSubtype, game, socketId, vars) {
     }
 }
 
+const MODERATOR_TYPES = [USER_TYPES.MODERATOR, USER_TYPES.TEMPORARY_MODERATOR];
+const PLAYER_TYPES = [USER_TYPES.PLAYER, USER_TYPES.KILLED_PLAYER, USER_TYPES.TEMPORARY_MODERATOR];
+
+function isModeratorOrTempMod (person) {
+    return MODERATOR_TYPES.includes(person.userType);
+}
+
+function isPlayerOrMod (person) {
+    return MODERATOR_TYPES.includes(person.userType) || PLAYER_TYPES.includes(person.userType);
+}
+
 const Events = [
     {
         id: EVENT_IDS.PLAYER_JOINED,
@@ -108,6 +119,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.KICK_PERSON,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             const toBeClearedIndex = game.people.findIndex(
                 (person) => person.id === socketArgs.personId && person.assigned === true
@@ -182,6 +194,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.UPDATE_GAME_ROLES,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             if (GameCreationRequest.deckIsValid(socketArgs.deck)) {
                 game.deck = socketArgs.deck;
@@ -247,6 +260,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.START_GAME,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             if (game.isStartable) {
                 game.status = STATUS.IN_PROGRESS;
@@ -266,6 +280,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.KILL_PLAYER,
+        authorize: (person, game) => isModeratorOrTempMod(person) || (game.hasAllKillPermission && isPlayerOrMod(person)),
         stateChange: async (game, socketArgs, vars) => {
             const person = game.people.find((person) => person.id === socketArgs.personId);
             if (person && !person.out) {
@@ -285,6 +300,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.REVEAL_PLAYER,
+        authorize: (person, game) => isModeratorOrTempMod(person) || (game.hasAllKillPermission && isPlayerOrMod(person)),
         stateChange: async (game, socketArgs, vars) => {
             const person = game.people.find((person) => person.id === socketArgs.personId);
             if (person && !person.revealed) {
@@ -307,6 +323,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.END_GAME,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             game.status = STATUS.ENDED;
             if (game.hasTimer && vars.gameManager.timers[game.accessCode]) {
@@ -328,6 +345,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.TRANSFER_MODERATOR,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             const currentModerator = vars.gameManager.findPersonByField(game, 'id', game.currentModeratorId);
             const toTransferTo = vars.gameManager.findPersonByField(game, 'id', socketArgs.personId);
@@ -353,6 +371,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.ASSIGN_DEDICATED_MOD,
+        authorize: (person, game) => isModeratorOrTempMod(person) || (game.hasAllKillPermission && isPlayerOrMod(person)),
         stateChange: async (game, socketArgs, vars) => {
             const currentModerator = vars.gameManager.findPersonByField(game, 'id', game.currentModeratorId);
             const toTransferTo = vars.gameManager.findPersonByField(game, 'id', socketArgs.personId);
@@ -438,6 +457,7 @@ const Events = [
     },
     {
         id: EVENT_IDS.UPDATE_GAME_TIMER,
+        authorize: (person) => isModeratorOrTempMod(person),
         stateChange: async (game, socketArgs, vars) => {
             if (GameCreationRequest.timerParamsAreValid(socketArgs.hasTimer, socketArgs.timerParams)) {
                 game.hasTimer = socketArgs.hasTimer;

--- a/server/modules/GameStateCurator.js
+++ b/server/modules/GameStateCurator.js
@@ -71,7 +71,8 @@ function getGameStateBasedOnPermissions (game, person) {
                 gameSize: game.gameSize,
                 people: GameStateCurator.mapPeopleForModerator(game.people, client),
                 timerParams: game.timerParams,
-                isStartable: game.isStartable
+                isStartable: game.isStartable,
+                hasAllKillPermission: game.hasAllKillPermission
             };
         case USER_TYPES.TEMPORARY_MODERATOR:
         case USER_TYPES.SPECTATOR:
@@ -90,7 +91,8 @@ function getGameStateBasedOnPermissions (game, person) {
                     })
                     .map((filteredPerson) => GameStateCurator.mapPerson(filteredPerson)),
                 timerParams: game.timerParams,
-                isStartable: game.isStartable
+                isStartable: game.isStartable,
+                hasAllKillPermission: game.hasAllKillPermission
             };
         default:
             break;

--- a/server/modules/singletons/EventManager.js
+++ b/server/modules/singletons/EventManager.js
@@ -193,6 +193,15 @@ class EventManager {
             timerEventSubtype: timerEventSubtype
         };
         if (event) {
+            if (event.authorize) {
+                const requestingPerson = requestingSocketId
+                    ? this.gameManager.findPersonByField(game, 'socketId', requestingSocketId)
+                    : null;
+                if (!syncOnly && requestingPerson && !event.authorize(requestingPerson, game)) {
+                    this.logger.warn('Unauthorized event ' + eventId + ' from ' + requestingPerson?.userType);
+                    return;
+                }
+            }
             if (!syncOnly || eventId === EVENT_IDS.RESTART_GAME) {
                 await event.stateChange(game, socketArgs, additionalVars);
             }

--- a/server/modules/singletons/GameManager.js
+++ b/server/modules/singletons/GameManager.js
@@ -66,7 +66,8 @@ class GameManager {
                 gameParams.timerParams,
                 gameParams.moderatorName,
                 gameParams.hasDedicatedModerator,
-                gameParams.isTestGame
+                gameParams.isTestGame,
+                gameParams.hasAllKillPermission
             );
             const newAccessCode = await this.generateAccessCode(PRIMITIVES.ACCESS_CODE_CHAR_POOL);
             if (newAccessCode === null) {
@@ -89,7 +90,8 @@ class GameManager {
                 req.hasDedicatedModerator,
                 moderator.id,
                 new Date().toJSON(),
-                req.timerParams
+                req.timerParams,
+                req.hasAllKillPermission
             );
             newGame.people = initializePeopleForGame(req.deck, moderator, this.shuffle, req.isTestGame, newGame.gameSize);
             newGame.isStartable = newGame.people.filter(person => person.userType === USER_TYPES.PLAYER

--- a/spec/unit/server/model/GameCreationRequest_Spec.js
+++ b/spec/unit/server/model/GameCreationRequest_Spec.js
@@ -101,4 +101,34 @@ describe('GameCreationRequest', () => {
             expect(GameCreationRequest.deckIsValid(deck)).toBe(false);
         });
     });
+
+    describe('#validate', () => {
+        const validParams = {
+            deck: [{ role: 'Villager', team: ALIGNMENT.GOOD, description: 'A villager', custom: false, quantity: 1 }],
+            hasTimer: false,
+            timerParams: null,
+            moderatorName: 'TestMod',
+            hasDedicatedModerator: true,
+            isTestGame: false,
+            hasAllKillPermission: false
+        };
+
+        it('should accept valid game params with hasAllKillPermission set to false', async () => {
+            await expectAsync(GameCreationRequest.validate(validParams)).toBeResolved();
+        });
+
+        it('should accept valid game params with hasAllKillPermission set to true', async () => {
+            await expectAsync(GameCreationRequest.validate({ ...validParams, hasAllKillPermission: true })).toBeResolved();
+        });
+
+        it('should reject game params when hasAllKillPermission is missing', async () => {
+            const params = { ...validParams };
+            delete params.hasAllKillPermission;
+            await expectAsync(GameCreationRequest.validate(params)).toBeRejected();
+        });
+
+        it('should reject game params when hasAllKillPermission is not a boolean', async () => {
+            await expectAsync(GameCreationRequest.validate({ ...validParams, hasAllKillPermission: 'yes' })).toBeRejected();
+        });
+    });
 });

--- a/spec/unit/server/modules/Events_Spec.js
+++ b/spec/unit/server/modules/Events_Spec.js
@@ -254,6 +254,18 @@ describe('Events', () => {
     });
 
     describe(EVENT_IDS.START_GAME, () => {
+        describe('authorize', () => {
+            it('should allow a moderator to start the game', () => {
+                const person = { userType: USER_TYPES.MODERATOR };
+                const result = Events.find((e) => e.id === EVENT_IDS.START_GAME).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+            it('should not allow a regular player to start the game', () => {
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.START_GAME).authorize(person, game);
+                expect(result).toBeFalse();
+            });
+        });
         describe('stateChange', () => {
             it('should start the game', async () => {
                 game.isStartable = true;
@@ -297,6 +309,30 @@ describe('Events', () => {
         });
     });
     describe(EVENT_IDS.KILL_PLAYER, () => {
+        describe('authorize', () => {
+            it('should allow a moderator to kill a player', () => {
+                const person = { userType: USER_TYPES.MODERATOR };
+                const result = Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+            it('should allow a temporary moderator to kill a player', () => {
+                const person = { userType: USER_TYPES.TEMPORARY_MODERATOR };
+                const result = Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+            it('should not allow a regular player to kill when hasAllKillPermission is false', () => {
+                game.hasAllKillPermission = false;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER).authorize(person, game);
+                expect(result).toBeFalse();
+            });
+            it('should allow a regular player to kill when hasAllKillPermission is true', () => {
+                game.hasAllKillPermission = true;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+        });
         describe('stateChange', () => {
             it('should kill the indicated player', async () => {
                 await Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER)
@@ -328,6 +364,25 @@ describe('Events', () => {
         });
     });
     describe(EVENT_IDS.REVEAL_PLAYER, () => {
+        describe('authorize', () => {
+            it('should allow a moderator to reveal a player', () => {
+                const person = { userType: USER_TYPES.MODERATOR };
+                const result = Events.find((e) => e.id === EVENT_IDS.REVEAL_PLAYER).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+            it('should not allow a regular player to reveal when hasAllKillPermission is false', () => {
+                game.hasAllKillPermission = false;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.REVEAL_PLAYER).authorize(person, game);
+                expect(result).toBeFalse();
+            });
+            it('should allow a regular player to reveal when hasAllKillPermission is true', () => {
+                game.hasAllKillPermission = true;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.REVEAL_PLAYER).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+        });
         describe('stateChange', () => {
             it('should reveal the indicated player', async () => {
                 await Events.find((e) => e.id === EVENT_IDS.REVEAL_PLAYER)
@@ -442,6 +497,25 @@ describe('Events', () => {
         });
     });
     describe(EVENT_IDS.ASSIGN_DEDICATED_MOD, () => {
+        describe('authorize', () => {
+            it('should allow a temporary moderator to assign a dedicated mod', () => {
+                const person = { userType: USER_TYPES.TEMPORARY_MODERATOR };
+                const result = Events.find((e) => e.id === EVENT_IDS.ASSIGN_DEDICATED_MOD).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+            it('should not allow a regular player when hasAllKillPermission is false', () => {
+                game.hasAllKillPermission = false;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.ASSIGN_DEDICATED_MOD).authorize(person, game);
+                expect(result).toBeFalse();
+            });
+            it('should allow a regular player when hasAllKillPermission is true', () => {
+                game.hasAllKillPermission = true;
+                const person = { userType: USER_TYPES.PLAYER };
+                const result = Events.find((e) => e.id === EVENT_IDS.ASSIGN_DEDICATED_MOD).authorize(person, game);
+                expect(result).toBeTrue();
+            });
+        });
         beforeEach(() => {
             game.people = [
                 { id: 'a', gameRole: 'Villager', alignment: 'good', assigned: true, out: false, killed: false, userType: USER_TYPES.TEMPORARY_MODERATOR },

--- a/spec/unit/server/modules/singletons/EventManager_Spec.js
+++ b/spec/unit/server/modules/singletons/EventManager_Spec.js
@@ -110,4 +110,3 @@ describe('EventManager', () => {
         });
     });
 });
-

--- a/spec/unit/server/modules/singletons/EventManager_Spec.js
+++ b/spec/unit/server/modules/singletons/EventManager_Spec.js
@@ -1,0 +1,113 @@
+const Game = require('../../../../../server/model/Game');
+const globals = require('../../../../../server/config/globals');
+const USER_TYPES = globals.USER_TYPES;
+const STATUS = globals.STATUS;
+const EVENT_IDS = globals.EVENT_IDS;
+const GameManager = require('../../../../../server/modules/singletons/GameManager.js');
+const EventManager = require('../../../../../server/modules/singletons/EventManager.js');
+const logger = require('../../../../../server/modules/Logger.js')(false);
+
+describe('EventManager', () => {
+    let gameManager, eventManager, namespace, game;
+
+    beforeAll(() => {
+        spyOn(logger, 'debug');
+        spyOn(logger, 'error');
+        spyOn(logger, 'warn');
+
+        const inObj = { emit: () => {} };
+        const toObj = { emit: () => {} };
+        namespace = { in: () => { return inObj; }, to: () => { return toObj; }, sockets: new Map() };
+        gameManager = GameManager.instance ? GameManager.instance : new GameManager(logger, globals.ENVIRONMENTS.PRODUCTION, 'test');
+        eventManager = EventManager.instance ? EventManager.instance : new EventManager(logger, 'test');
+        eventManager.publisher = { publish: async (...a) => {} };
+        gameManager.eventManager = eventManager;
+        eventManager.gameManager = gameManager;
+        gameManager.setGameSocketNamespace(namespace);
+    });
+
+    beforeEach(() => {
+        game = new Game(
+            'ABCD',
+            STATUS.IN_PROGRESS,
+            [
+                { id: 'a', name: 'ModPerson', socketId: 'socket-a', assigned: true, out: true, killed: false, userType: USER_TYPES.MODERATOR },
+                { id: 'b', name: 'PlayerOne', socketId: 'socket-b', gameRole: 'Villager', alignment: 'good', assigned: true, out: false, killed: false, userType: USER_TYPES.PLAYER },
+                { id: 'c', name: 'Spectator', socketId: 'socket-c', assigned: true, out: false, killed: false, userType: USER_TYPES.SPECTATOR }
+            ],
+            [{ quantity: 1 }, { quantity: 1 }],
+            false,
+            'a',
+            true,
+            'a',
+            new Date().toJSON(),
+            null
+        );
+        game.currentModeratorId = 'a';
+        namespace.sockets = new Map();
+        spyOn(namespace, 'in').and.callThrough();
+        spyOn(namespace.in(), 'emit').and.callThrough();
+    });
+
+    describe('#handleEventById - authorization', () => {
+        it('should block a regular player from killing when hasAllKillPermission is false', async () => {
+            game.hasAllKillPermission = false;
+            await eventManager.handleEventById(
+                EVENT_IDS.KILL_PLAYER, null, game, 'socket-b', game.accessCode, { personId: 'b' }, null, false
+            );
+            const person = game.people.find(p => p.id === 'b');
+            expect(person.out).toBeFalse();
+            expect(person.killed).toBeFalse();
+        });
+
+        it('should allow a regular player to kill when hasAllKillPermission is true', async () => {
+            game.hasAllKillPermission = true;
+            await eventManager.handleEventById(
+                EVENT_IDS.KILL_PLAYER, null, game, 'socket-b', game.accessCode, { personId: 'b' }, null, false
+            );
+            const person = game.people.find(p => p.id === 'b');
+            expect(person.out).toBeTrue();
+            expect(person.killed).toBeTrue();
+        });
+
+        it('should allow a moderator to kill regardless of hasAllKillPermission', async () => {
+            game.hasAllKillPermission = false;
+            await eventManager.handleEventById(
+                EVENT_IDS.KILL_PLAYER, null, game, 'socket-a', game.accessCode, { personId: 'b' }, null, false
+            );
+            const person = game.people.find(p => p.id === 'b');
+            expect(person.out).toBeTrue();
+            expect(person.killed).toBeTrue();
+        });
+
+        it('should block a spectator from killing even when hasAllKillPermission is true', async () => {
+            game.hasAllKillPermission = true;
+            game.people.find(p => p.id === 'c').out = false;
+            await eventManager.handleEventById(
+                EVENT_IDS.KILL_PLAYER, null, game, 'socket-c', game.accessCode, { personId: 'b' }, null, false
+            );
+            const person = game.people.find(p => p.id === 'b');
+            expect(person.out).toBeFalse();
+        });
+
+        it('should block a regular player from starting the game', async () => {
+            game.status = STATUS.LOBBY;
+            game.isStartable = true;
+            await eventManager.handleEventById(
+                EVENT_IDS.START_GAME, null, game, 'socket-b', game.accessCode, {}, null, false
+            );
+            expect(game.status).toEqual(STATUS.LOBBY);
+        });
+
+        it('should allow events without authorize to proceed for any user', async () => {
+            await eventManager.handleEventById(
+                EVENT_IDS.CHANGE_NAME, null, game, 'socket-b', game.accessCode,
+                { personId: 'b', newName: 'NewName' },
+                (result) => { },
+                false
+            );
+            expect(game.people.find(p => p.id === 'b').name).toEqual('NewName');
+        });
+    });
+});
+


### PR DESCRIPTION
We received feedback that sometimes players need to be able to kill without the need to tell a moderator. This is because some games are played with a kill on the very first night, and if you don't have a dedicated moderator, there is no way to kill a player through the app without letting someone know that shouldn't have that information. So, we added an option during game creation to let anybody kill/reveal players.

<img width="684" height="642" alt="image" src="https://github.com/user-attachments/assets/914bb0d0-6bdb-4d88-915f-984e7b7133e5" />
