### PR TITLE
filter out fields that shouldn't be seen for KILL_PLAYER event, finer grain logic for communicating state for the event

### DIFF
--- a/server/modules/Events.js
+++ b/server/modules/Events.js
@@ -289,7 +289,17 @@ const Events = [
         communicate: async (game, socketArgs, vars) => {
             const person = game.people.find((person) => person.id === socketArgs.personId);
             if (person) {
-                vars.gameManager.namespace.in(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, person);
+                const moderator = vars.gameManager.findPersonByField(game, 'id', game.currentModeratorId);
+                const moderatorSocket = vars.gameManager.namespace.sockets.get(moderator?.socketId);
+                if (moderator && moderatorSocket) {
+                    vars.gameManager.namespace.to(moderator.socketId).emit(
+                        EVENT_IDS.KILL_PLAYER,
+                        GameStateCurator.mapPersonForModerator(person)
+                    );
+                    moderatorSocket.to(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(person));
+                } else {
+                    vars.gameManager.namespace.in(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(person));
+                }
             }
         }
     },
@@ -387,9 +397,9 @@ const Events = [
             const moderatorSocket = vars.gameManager.namespace.sockets.get(moderator?.socketId);
             if (moderator && moderatorSocket) {
                 vars.gameManager.namespace.to(moderator.socketId).emit(EVENT_IDS.SYNC_GAME_STATE);
-                moderatorSocket.to(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, moderator);
+                moderatorSocket.to(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(moderator));
             } else {
-                vars.gameManager.namespace.in(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, moderator);
+                vars.gameManager.namespace.in(game.accessCode).emit(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(moderator));
             }
             const previousModerator = vars.gameManager.findPersonByField(game, 'id', game.previousModeratorId);
             if (previousModerator && previousModerator.id !== moderator.id && vars.gameManager.namespace.sockets.get(previousModerator.socketId)) {

--- a/server/modules/GameStateCurator.js
+++ b/server/modules/GameStateCurator.js
@@ -14,17 +14,10 @@ const GameStateCurator = {
             .filter((person) => {
                 return person.assigned === true || (person.userType === USER_TYPES.SPECTATOR || person.userType === USER_TYPES.MODERATOR);
             })
-            .map((person) => ({
-                name: person.name,
-                id: person.id,
-                userType: person.userType,
-                gameRole: person.gameRole,
-                gameRoleDescription: person.gameRoleDescription,
-                alignment: person.alignment,
-                out: person.out,
-                killed: person.killed,
-                revealed: person.revealed
-            }));
+            .map(toModeratorPersonView);
+    },
+    mapPersonForModerator: (person) => {
+        return toModeratorPersonView(person);
     },
     mapPerson: (person) => {
         if (person.revealed) {
@@ -95,6 +88,20 @@ function getGameStateBasedOnPermissions (game, person) {
         default:
             break;
     }
+}
+
+function toModeratorPersonView (person) {
+    return {
+        name: person.name,
+        id: person.id,
+        userType: person.userType,
+        gameRole: person.gameRole,
+        gameRoleDescription: person.gameRoleDescription,
+        alignment: person.alignment,
+        out: person.out,
+        killed: person.killed,
+        revealed: person.revealed
+    };
 }
 
 module.exports = GameStateCurator;

--- a/spec/e2e/game_spec.js
+++ b/spec/e2e/game_spec.js
@@ -262,7 +262,11 @@ describe('game page', () => {
             );
             mockSocket.eventHandlers.killPlayer({
                 id: 'pTtVXDJaxtXcrlbG8B43Wom67snoeO24RNEkO6eB2BaIftTdvpnfe1QR65DVj9A6I3VOoKZkYQW',
+                name: 'Andrea',
                 userType: USER_TYPES.KILLED_PLAYER,
+                gameRole: 'Villager',
+                gameRoleDescription: 'During the day, find the wolves and kill them.',
+                alignment: 'good',
                 out: true,
                 killed: true,
                 revealed: false

--- a/spec/e2e/game_spec.js
+++ b/spec/e2e/game_spec.js
@@ -265,8 +265,7 @@ describe('game page', () => {
                 userType: USER_TYPES.KILLED_PLAYER,
                 out: true,
                 killed: true,
-                revealed: false,
-                alignment: 'good'
+                revealed: false
             });
             expect(document.querySelector('div[data-pointer="pTtVXDJaxtXcrlbG8B43Wom67snoeO24RNEkO6eB2BaIftTdvpnfe1QR65DVj9A6I3VOoKZkYQW"].game-player.killed')
             ).not.toBeNull();

--- a/spec/unit/server/modules/Events_Spec.js
+++ b/spec/unit/server/modules/Events_Spec.js
@@ -316,14 +316,44 @@ describe('Events', () => {
             });
         });
         describe('communicate', () => {
-            it('should communicate the killed player to the room', async () => {
+            it('should communicate the killed player to the room without sensitive fields', async () => {
+                const person = game.people.find(p => p.id === 'b');
                 await Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER)
                     .communicate(game, { personId: 'b' }, { gameManager: gameManager });
                 expect(namespace.in).toHaveBeenCalledWith(game.accessCode);
                 expect(namespace.in().emit).toHaveBeenCalledWith(
                     EVENT_IDS.KILL_PLAYER,
-                    game.people.find(p => p.id === 'b')
+                    GameStateCurator.mapPerson(person)
                 );
+                const emittedPerson = namespace.in().emit.calls.mostRecent().args[1];
+                expect(emittedPerson.cookie).toBeUndefined();
+                expect(emittedPerson.socketId).toBeUndefined();
+            });
+            it('should send full role/alignment data to the moderator socket, and limited data to everyone else', async () => {
+                const person = game.people.find(p => p.id === 'b');
+                const moderator = game.people.find(p => p.id === 'a');
+                moderator.socketId = 'mod-socket-id';
+                const socketToObj = { emit: () => {} };
+                spyOn(socketToObj, 'emit').and.callThrough();
+                const modSocket = { to: () => socketToObj, emit: () => {} };
+                spyOn(modSocket, 'to').and.callThrough();
+                namespace.sockets.set('mod-socket-id', modSocket);
+                spyOn(GameStateCurator, 'mapPersonForModerator').and.callThrough();
+                await Events.find((e) => e.id === EVENT_IDS.KILL_PLAYER)
+                    .communicate(game, { personId: 'b' }, { gameManager: gameManager });
+                // moderator gets full data with alignment
+                expect(namespace.to).toHaveBeenCalledWith('mod-socket-id');
+                expect(namespace.to().emit).toHaveBeenCalledWith(
+                    EVENT_IDS.KILL_PLAYER,
+                    GameStateCurator.mapPersonForModerator(person)
+                );
+                const modEmitted = namespace.to().emit.calls.mostRecent().args[1];
+                expect(modEmitted.alignment).toBeDefined();
+                // everyone else gets limited data
+                expect(modSocket.to).toHaveBeenCalledWith(game.accessCode);
+                expect(socketToObj.emit).toHaveBeenCalledWith(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(person));
+                const otherEmitted = socketToObj.emit.calls.mostRecent().args[1];
+                expect(otherEmitted.alignment).toBeUndefined();
             });
         });
     });
@@ -494,7 +524,7 @@ describe('Events', () => {
                 expect(namespace.to().emit).toHaveBeenCalledWith(EVENT_IDS.SYNC_GAME_STATE);
                 // verify the "kill player" event is sent to everyone but the sender
                 expect(mockSocket.to).toHaveBeenCalledWith(game.accessCode);
-                expect(socketToObj.emit).toHaveBeenCalledWith(EVENT_IDS.KILL_PLAYER, game.people.find(p => p.id === 'a'));
+                expect(socketToObj.emit).toHaveBeenCalledWith(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(game.people.find(p => p.id === 'a')));
             });
             it('should not communicate to the current or previous mod if their sockets are not found', async () => {
                 game.currentModeratorId = 'a';
@@ -522,7 +552,7 @@ describe('Events', () => {
                 expect(namespace.to().emit).not.toHaveBeenCalled();
                 // verify the "kill player" event is sent to everyone in the room (as opposed to everyone but the sender)
                 expect(namespace.in).toHaveBeenCalledWith(game.accessCode);
-                expect(namespace.in().emit).toHaveBeenCalledWith(EVENT_IDS.KILL_PLAYER, game.people.find(p => p.id === 'a'));
+                expect(namespace.in().emit).toHaveBeenCalledWith(EVENT_IDS.KILL_PLAYER, GameStateCurator.mapPerson(game.people.find(p => p.id === 'a')));
             });
         });
     });


### PR DESCRIPTION
- the KILL_PLAYER and ASSIGN_DEDICATED_MOD events were neglecting to invoke the GameStateCurator module to make sure game state is appropriately mapped per the user's permissions. This was causing us to erroneously include a persons cookie and socket ID, which are meant to be seen by the server only and could theoretically be used to assume the role and permissions of someone else during the game.

### Fix
Fixes #223 

- Edit the events to use the game state curator to properly filter out certain fields.
- Edit the "communicate" function for these events to make sure they are invoking different mapping logic for dedicated moderators vs. everyone else. In particular, if a player is killed and not revealed, moderators should still receive alignment information in the response, while everyone else should not. So if a given server instance has the moderator socket connected to it, communicate a different response to them vs. everyone else.

### Testing

- unit tests to verify key components of the fix
- verified that the socket event no longer includes the cookie or socket ID for KILL_PLAYER and ASSIGN_DEDICATED_MOD:

**Kill player**

<img width="1310" height="458" alt="image" src="https://github.com/user-attachments/assets/fd95449f-5860-4f45-953b-c8625dfcff44" />

also verified the game state looks correct from all the different views (moderator, the player that was killed, and a spectator):

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f2614b96-5793-46c8-9854-882545f2c5d6" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d582c89c-60b6-4877-a000-ddfafb9451c7" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e70b940f-fc89-4926-aac4-339698500588" />

**Assign Dedicated Mod -> Kill Player** (When a temporary moderator kills the first player, as part of assigning a dedicated mod we also emit the kill player event)

<img width="1262" height="310" alt="image" src="https://github.com/user-attachments/assets/549ad000-89c5-433d-a419-9529a280eb60" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/879e6644-ec36-40b5-8f94-17ec35f55ce7" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/13947550-af09-49d6-8d40-2fbc64e1bf57" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/722bd2cc-3e4b-4472-8c4f-c69bbe62487d" />
